### PR TITLE
Arreglado Callback para JSONArray en vez de JSONObject

### DIFF
--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -2,6 +2,7 @@
 <project version="4">
   <component name="ProjectModuleManager">
     <modules>
+      <module fileurl="file://$PROJECT_DIR$/Tvify.iml" filepath="$PROJECT_DIR$/Tvify.iml" />
       <module fileurl="file://$PROJECT_DIR$/TvifyAndroid.iml" filepath="$PROJECT_DIR$/TvifyAndroid.iml" />
       <module fileurl="file://$PROJECT_DIR$/app/app.iml" filepath="$PROJECT_DIR$/app/app.iml" />
     </modules>

--- a/app/src/main/java/com/develop/mauriciodinki/tvify/io/TvMazeApiService.java
+++ b/app/src/main/java/com/develop/mauriciodinki/tvify/io/TvMazeApiService.java
@@ -2,6 +2,7 @@ package com.develop.mauriciodinki.tvify.io;
 
 import com.develop.mauriciodinki.tvify.io.model.ShowsResponse;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import retrofit.Callback;
@@ -13,5 +14,5 @@ import retrofit.http.GET;
 public interface TvMazeApiService {
 
     @GET("/shows")
-    void getShows(Callback <ShowsResponse> serverResponse);
+    void getShows(Callback <ArrayList<ShowsResponse>> serverResponse);
 }

--- a/app/src/main/java/com/develop/mauriciodinki/tvify/ui/ShowsFragment.java
+++ b/app/src/main/java/com/develop/mauriciodinki/tvify/ui/ShowsFragment.java
@@ -24,7 +24,7 @@ import retrofit.client.Response;
 /**
  * Created by mauriciodinki on 23/12/15.
  */
-public class ShowsFragment extends Fragment implements Callback<ShowsResponse> {
+public class ShowsFragment extends Fragment implements Callback<ArrayList<ShowsResponse>> {
 
     public static final int NUM_COLUMNS = 2;
     private RecyclerView mShowList;
@@ -61,10 +61,10 @@ public class ShowsFragment extends Fragment implements Callback<ShowsResponse> {
         mShowList.addItemDecoration(new ItemOffsetDecoration(getActivity(), R.integer.offset));
     }
 
-
     @Override
-    public void success(ShowsResponse showsResponse, Response response) {
-        adapter.addAll(showsResponse.getShows());
+    public void success(ArrayList<ShowsResponse> showsResponses, Response response) {
+        for (int i = 0; i <= showsResponses.size()-1; i++)
+            adapter.addAll(showsResponses.get(i));
     }
 
     @Override

--- a/app/src/main/java/com/develop/mauriciodinki/tvify/ui/adapter/ShowListAdapter.java
+++ b/app/src/main/java/com/develop/mauriciodinki/tvify/ui/adapter/ShowListAdapter.java
@@ -11,8 +11,10 @@ import android.widget.TextView;
 
 import com.develop.mauriciodinki.tvify.R;
 import com.develop.mauriciodinki.tvify.domain.Show;
+import com.develop.mauriciodinki.tvify.io.model.ShowsResponse;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 
 /**
@@ -48,11 +50,11 @@ public class ShowListAdapter extends RecyclerView.Adapter<ShowListAdapter.ShowLi
         return shows.size();
     }
 
-    public void addAll(@NonNull ArrayList<Show> shows){
+    public void addAll(@NonNull ShowsResponse shows){
         if (shows == null)
             throw  new NullPointerException("The items cannot be null");
 
-        this.shows.addAll(shows);
+        this.shows.addAll((Collection<? extends Show>) shows);
         notifyDataSetChanged();
     }
 


### PR DESCRIPTION
Dinki!, Solo habia que cambiar el Callback de tus metodos para ArrayList, cuando tu haces Callback<TuObjeto> le dices que esperas un objeto de la clase TuObjeto, pero si le dices Callback<(Implementacion de la interfaz List)<TuObjeto>> le dices que esperas un Array del JSON (y te lo agrega a alguna implementación de la Interfaz List) , usualmente usan List<> pero por performance, ArrayList<> es mejor, (también hay que modificar los overrides de los metodos para tu Callback).

No te entendia muy bien por messenger. :v
